### PR TITLE
Fix 'Even more info' href for class 'mobile'

### DIFF
--- a/quickstartEN/index.html
+++ b/quickstartEN/index.html
@@ -39,7 +39,7 @@
               <li><a class="dropdown" target="_parent"  href="resources.html">Resources</a></li>
             </ul>
           </li>
-          <li><a class="mobile" target="_parent"  href="appendix.html">Even More Info</a><a class="nav" target="_parent"  href="appendix.html">Credits</a>
+          <li><a class="mobile" target="_parent"  href="resources.html">Even More Info</a><a class="nav" target="_parent"  href="appendix.html">Credits</a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
Menu items 'Even more info' and 'Credits' of the 'mobile' class both are linked to the same target: appendix.html.
And I'm not sure. You may want to link this item to the quickfaq.html target,